### PR TITLE
Added default Joi option abortEarly = false

### DIFF
--- a/lib/expressJoi.js
+++ b/lib/expressJoi.js
@@ -19,7 +19,7 @@ var util = require('util');
  * @public
  */
 exports.joiValidate = function joiValidate(validations, options) {
-  options = options || {};
+  options = options || {"abortEarly": false};
   var strict = !!options.strict;
   delete options.strict;
 


### PR DESCRIPTION
This causes Joi to process all of the items and find all of the validation errors, not just the first error.

I'm pretty sure the original express-joi processed for all errors; this must be a new default behavior of Joi.
